### PR TITLE
Adcampaign

### DIFF
--- a/advertising/adStore.js
+++ b/advertising/adStore.js
@@ -112,10 +112,16 @@ function selectAdByID(adID){
 	return knex('advertisement').select().where({id: adID})
 }
 
+//TODO this should eventually become something based off of an organization ID
+function selectAdsByUserID(userID){
+	return knex('advertisement').select().where({owner_id: userID})
+}
+
 module.exports = {
 	saveAdToDB,
 	getAllAds,
 	linkAdToPodcast,
 	getLinkedAdID,
-	selectAdByID
+	selectAdByID,
+	selectAdsByUserID
 }

--- a/advertising/adcampaign/campaignStore.js
+++ b/advertising/adcampaign/campaignStore.js
@@ -1,0 +1,3 @@
+/**
+ * http://usejsdoc.org/
+ */

--- a/advertising/adcampaign/campaignStore.js
+++ b/advertising/adcampaign/campaignStore.js
@@ -1,3 +1,22 @@
 /**
  * http://usejsdoc.org/
  */
+const knex = require('knex')(require('../../knexfile'))
+
+function insertAdCampaign(campaign, userID){
+	return knex('adcampaign').insert({
+		title: campaign.title,
+		description: campaign.description,
+		init_amount: campaign.budget,
+		curr_amount: campaign.budget,
+		pay_per_view: campaign.price,
+		allow_cancel_after: campaign.cancel_date,
+		allow_execute_after: campaign.start_date,
+		ad_id: campaign.ads,
+		user_id: userID
+	}, 'id').then((result) => {
+        return { success: true, id: result[0] }
+      })
+
+}
+module.exports = {insertAdCampaign}

--- a/advertising/adcampaign/routes.js
+++ b/advertising/adcampaign/routes.js
@@ -8,7 +8,24 @@ const session = require('../../authentication/session')
 const adStore = require('../adStore')
 
 router.get('/campaign', session.requireLogin, (req, res) => {
-	res.render('campaign')
+	let userID = req.session.user.id
+	adStore.selectAdsByUserID(userID).then((ads) => {
+		let dropdown = []
+		let itemsProcessed = 0
+		ads.forEach(function(el){
+			let ad = {}
+			ad.name = el.ad_name
+			ad.id = el.id
+			dropdown.push(ad)
+			itemsProcessed++
+			if(itemsProcessed === ads.length){
+				console.log('dropdown', dropdown)
+				res.render('campaign', {
+					ads: dropdown
+				})
+			}
+		})
+	})
 })
 
 module.exports = router

--- a/advertising/adcampaign/routes.js
+++ b/advertising/adcampaign/routes.js
@@ -6,6 +6,7 @@ const router = express.Router()
 const bodyParser = require('body-parser')
 const session = require('../../authentication/session')
 const adStore = require('../adStore')
+const campaignStore = require('./campaignStore')
 
 router.get('/campaign', session.requireLogin, (req, res) => {
 	let userID = req.session.user.id
@@ -25,6 +26,17 @@ router.get('/campaign', session.requireLogin, (req, res) => {
 				})
 			}
 		})
+	})
+})
+
+router.post('/createCampaign', session.requireLogin, (req, res) => {
+	console.log(req.body)
+	let userID = req.session.user.id
+	campaignStore.insertAdCampaign(req.body, userID).then(({success}) => {
+		if(success) {
+			res.send('Success!\n<form action="/dashboard" method = "get"><button>Return to Dashboard</button></form>')
+		}
+		else res.sendStatus(400)
 	})
 })
 

--- a/advertising/adcampaign/routes.js
+++ b/advertising/adcampaign/routes.js
@@ -1,0 +1,14 @@
+/**
+ * http://usejsdoc.org/
+ */
+const express = require('express')
+const router = express.Router()
+const bodyParser = require('body-parser')
+const session = require('../../authentication/session')
+const adStore = require('../adStore')
+
+router.get('/campaign', session.requireLogin, (req, res) => {
+	res.render('campaign')
+})
+
+module.exports = router

--- a/app.js
+++ b/app.js
@@ -14,6 +14,7 @@ app.use(require('./rss/routes'))
 app.use(require('./wallet/routes'))
 app.use(require('./rippled/routes'))
 app.use(require('./advertising/routes'))
+app.use(require('./advertising/adcampaign/routes'))
 
 app.listen(3000, () => {
 	console.log('Server running on http://localhost:3000')

--- a/migrations/20190131115114_create_escrow_table.js
+++ b/migrations/20190131115114_create_escrow_table.js
@@ -1,0 +1,21 @@
+exports.up = function(knex, Promise) {
+	return knex.schema.createTable('escrow', function(table) {
+		  table.increments('id').primary()
+		  table.string("amout").notNullable().defaultTo('0.000000')
+		  table.string('destination').notNullable().defaultTo('undefined')
+		  table.string('allow_cancel_after') //TODO will want this to be a datetime. which format, I'm not sure yet
+		  table.string('allow_execute_after') //TODO see above
+		  table.string('condition')
+		  table.string('destination_tag')
+		  table.string('memos')
+		  table.string('source_tag')
+		  //.unsigned().notNullable() is the same as .increments() under the hood. It is necessary here
+		  table.integer('ad_id').unsigned().notNullable().references('id').inTable('advertisement').onDelete('NO ACTION').onUpdate('NO ACTION').defaultTo(1)
+		  table.integer('podcast_id').unsigned().notNullable().references('id').inTable('podcast').onDelete('NO ACTION').onUpdate('NO ACTION').defaultTo(1)
+		  table.timestamps(false, true) //creates created_at and updated_at columns
+	  })
+};
+
+exports.down = function(knex, Promise) {
+	return knex.schema.dropTableIfExists('escrow')
+};

--- a/migrations/20190131121553_create_ad_campaign_table.js
+++ b/migrations/20190131121553_create_ad_campaign_table.js
@@ -1,0 +1,18 @@
+exports.up = function(knex, Promise) {
+	return knex.schema.createTable('adcampaign', function(table) {
+		  table.increments('id').primary()
+		  table.string("init_amout").notNullable().defaultTo('0.000000')
+		  table.string("curr_amout").notNullable().defaultTo('0.000000')
+		  table.string('pay_per_view').notNullable().defaultTo('0.000000')
+		  table.string('allow_cancel_after') //TODO will want this to be a datetime. which format, I'm not sure yet
+		  table.string('allow_execute_after') //TODO see above
+		  //.unsigned().notNullable() is the same as .increments() under the hood. It is necessary here
+		  table.integer('ad_id').unsigned().notNullable().references('id').inTable('advertisement').onDelete('NO ACTION').onUpdate('NO ACTION').defaultTo(1)
+		  table.integer('user_id').unsigned().notNullable().references('id').inTable('user').onDelete('NO ACTION').onUpdate('NO ACTION').defaultTo(1)
+		  table.timestamps(false, true) //creates created_at and updated_at columns
+	  })
+};
+
+exports.down = function(knex, Promise) {
+	return knex.schema.dropTableIfExists('adcampaign')
+};

--- a/migrations/20190131122050_add_ad_campaign_foreign_key_to_escrow_table.js
+++ b/migrations/20190131122050_add_ad_campaign_foreign_key_to_escrow_table.js
@@ -1,0 +1,11 @@
+exports.up = function(knex, Promise) {
+  return knex.schema.alterTable('escrow', function(table){
+	  table.integer('campaign_id').unsigned().notNullable().references('id').inTable('adcampaign').after('ad_id').onDelete('NO ACTION').onUpdate('NO ACTION').defaultTo(1)
+  })
+};
+
+exports.down = function(knex, Promise) {
+	return knex.schema.table('escrow', t => {
+		  t.dropColumn('campaign_id')
+	  })
+};

--- a/migrations/20190131124829_add_title_and_description_columns_to_adcampaign_table.js
+++ b/migrations/20190131124829_add_title_and_description_columns_to_adcampaign_table.js
@@ -1,0 +1,14 @@
+
+exports.up = function(knex, Promise) {
+	 return knex.schema.alterTable('adcampaign', function(table){
+		  table.string('title')
+		  table.string('description').after('title')
+	  })
+};
+
+exports.down = function(knex, Promise) {
+	return knex.schema.table('adcampaign', t => {
+		  t.dropColumn('title')
+		  t.dropColumn('description')
+	  })
+};

--- a/migrations/20190131134710_spellcheck_on_adcampaign.js
+++ b/migrations/20190131134710_spellcheck_on_adcampaign.js
@@ -1,0 +1,14 @@
+
+exports.up = function(knex, Promise) {
+	 return knex.schema.alterTable('adcampaign', function(table){
+		  table.renameColumn('curr_amout', 'curr_amount')
+		  table.renameColumn('init_amout', 'init_amount')
+	  })
+};
+
+exports.down = function(knex, Promise) {
+	return knex.schema.alterTable('adcampaign', function(table){
+		  table.renameColumn('curr_amount', 'curr_amout')
+		  table.renameColumn('init_amount', 'init_amout')
+	  })
+};

--- a/views/campaign.ejs
+++ b/views/campaign.ejs
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="ISO-8859-1">
+<title>Create Advertising Campaign</title>
+</head>
+<body>
+	<form action="/createCampaign" method="post" enctype="multipart/form-data">
+		<table border="0">
+			<tr>
+				<td>Title: </td>
+				<td><input type="text" name="title" size="50"/></td>
+			</tr>
+			<tr>
+				<td>Description: </td>
+				<td><input type="text" name="description" size="50"/></td>
+			</tr>
+			<tr>
+				<td>Budget: </td>
+				<td><input type="text" name="budget" size="50"/></td>
+			</tr>
+			<tr>
+				<td>Price per listen: </td>
+				<td><input type="text" name="price" size="50"/></td>
+			</tr>
+			<tr>
+				<td>Allow cancel after: </td>
+				<td><input type="text" name="cancel_date" size="50"/></td>
+			</tr>
+			<tr>
+				<td>Execute after: </td>
+				<td><input type="text" name="start_date" size="50"/></td>
+			</tr>
+			<tr>
+				<td>Advertisement: </td>
+				<td>
+					<select name="ads">
+    					<option value="TODO">Fill Dynamically</option>
+  					</select>
+  				</td>
+			</tr>
+			<tr>
+            	<td colspan="2">
+            		<input type="submit" value="Create">
+                </td>
+            </tr>
+		</table>
+	</form>
+	<br>
+	<form action="/dashboard" method = "get">
+          <button>Back</button>
+    </form> 
+	<form action="/logout" method = "get">
+          <button>Logout</button>
+    </form>
+</body>
+</html>

--- a/views/campaign.ejs
+++ b/views/campaign.ejs
@@ -35,7 +35,9 @@
 				<td>Advertisement: </td>
 				<td>
 					<select name="ads">
-    					<option value="TODO">Fill Dynamically</option>
+						<% ads.forEach(function(ad){ %>
+							<option value=<%=ad.id %>><%=ad.name %></option>
+						<% }) %>	
   					</select>
   				</td>
 			</tr>

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -20,6 +20,9 @@
     </form>  
     <form action="/getAddStore" method = "get">
           <button>Link Advertisement</button>
+    </form>
+    <form action="/campaign" method = "get">
+          <button>Create Ad Campaign</button>
     </form> 
     <form action="/wallet" method = "get">
     	<button>View Wallet</button>


### PR DESCRIPTION
This pull request creates functionality that allows a user to create the specifications for an ad campaign. They select a budget, the price paid per listen, the ad they want to run, and some other run parameters. A job executor needs to be created that will create escrow contracts for content creators when they choose to attach an ad to their content. Attaching an ad to a podcast will also need to be retooled to take into account adcampaigns instead of individual ads. Furthermore, some sort of user profile distinction needs to be created to differentiate between content creators and advertisers.