### PR TITLE
Play linked ad

### DIFF
--- a/advertising/adStore.js
+++ b/advertising/adStore.js
@@ -118,6 +118,10 @@ function getLinkedAdID(podcastID){
 	return knex('adlink').select('ad_ID').where({podcast_ID: podcastID})
 }
 
+function removeLink(podcastID, adID){
+	return knex('adlink').where({ad_id: adID, podcast_id: podcastID}).del()
+}
+
 function selectAdByID(adID){
 	return knex('advertisement').select().where({id: adID})
 }
@@ -138,5 +142,6 @@ module.exports = {
 	getLinkedAdID,
 	selectAdByID,
 	selectAdsByUserID,
-	selectAdsWhereInByID
+	selectAdsWhereInByID,
+	removeLink
 }

--- a/advertising/adStore.js
+++ b/advertising/adStore.js
@@ -75,6 +75,16 @@ function saveAdToDB(req, res, {ad_name, description, owner_id}) {
       })
 }
 
+/**
+ * 
+ * This may be deprecated or may be incorporated somewhere else.
+ * It was initially used to mock up ad linkages, but those should
+ * now be based on ad campaigns
+ * 
+ * @deprecated 
+ * @param callback
+ * @returns
+ */
 function getAllAds(callback){
 	selectAllAds(function(ads){
 		callback(ads);
@@ -117,11 +127,16 @@ function selectAdsByUserID(userID){
 	return knex('advertisement').select().where({owner_id: userID})
 }
 
+function selectAdsWhereInByID(arrayOfAdIDs){
+	return knex('advertisement').select().whereIn('id', arrayOfAdIDs)
+}
+
 module.exports = {
 	saveAdToDB,
 	getAllAds,
 	linkAdToPodcast,
 	getLinkedAdID,
 	selectAdByID,
-	selectAdsByUserID
+	selectAdsByUserID,
+	selectAdsWhereInByID
 }

--- a/advertising/adcampaign/campaignStore.js
+++ b/advertising/adcampaign/campaignStore.js
@@ -19,4 +19,17 @@ function insertAdCampaign(campaign, userID){
       })
 
 }
-module.exports = {insertAdCampaign}
+
+function selectAllAdCampaigns(){
+	return knex('adcampaign')
+}
+
+function getAdCampaignForAd(adID){
+	return knex('adcampaign').where({ad_id: adID})
+}
+
+module.exports = {
+		insertAdCampaign,
+		getAdCampaignForAd,
+		selectAllAdCampaigns
+	}

--- a/advertising/adcampaign/campaignStore.js
+++ b/advertising/adcampaign/campaignStore.js
@@ -28,8 +28,21 @@ function getAdCampaignForAd(adID){
 	return knex('adcampaign').where({ad_id: adID})
 }
 
+function deleteCampaign(campaignID){
+	console.log('Removing campaign with ID ' + campaingID)
+	return knex('adcampaign').where({id: campaignID}).del()
+}
+
+function updateCurrAmount(id, newBalance){
+	console.log("id:", id)
+	console.log("new balance:", newBalance)
+	return knex('adcampaign').where({id: id}).update({curr_amount: newBalance})
+}
+
 module.exports = {
 		insertAdCampaign,
 		getAdCampaignForAd,
-		selectAllAdCampaigns
+		selectAllAdCampaigns,
+		deleteCampaign,
+		updateCurrAmount
 	}

--- a/advertising/adcampaign/routes.js
+++ b/advertising/adcampaign/routes.js
@@ -11,14 +11,21 @@ const campaignStore = require('./campaignStore')
 router.get('/campaign', session.requireLogin, (req, res) => {
 	let userID = req.session.user.id
 	adStore.selectAdsByUserID(userID).then((ads) => {
+		// You can't create a campaign if you haven't uploaded an ad yet
+		if(ads.length === 0){
+			res.send('You must create an ad first!\n<form action="/dashboard" method = "get"><button>Return to Dashboard</button></form>')
+			return
+		}
 		let dropdown = []
 		let itemsProcessed = 0
+		console.log('lenght', ads.length)
 		ads.forEach(function(el){
 			let ad = {}
 			ad.name = el.ad_name
 			ad.id = el.id
 			dropdown.push(ad)
 			itemsProcessed++
+			console.log('items processed', itemsProcessed)
 			if(itemsProcessed === ads.length){
 				console.log('dropdown', dropdown)
 				res.render('campaign', {

--- a/advertising/routes.js
+++ b/advertising/routes.js
@@ -8,6 +8,7 @@ const fileupload = require("express-fileupload"); //TODO too slow for large file
 const session = require('../authentication/session')
 const adStore = require('./adStore')
 const podcastStore = require('../podcast/podcastStore')
+const campaignStore = require('./adcampaign/campaignStore')
 const fs = require('fs')
 
 router.use(bodyParser.json())
@@ -16,10 +17,22 @@ router.get('/uploadAd', session.requireLogin, (req, res) => {
 	res.render('uploadAd')
 })
 
-router.get('/getAddStore', session.requireLogin, (req, res) => {
-	adStore.getAllAds(function(ads){
-		res.render('advertisement', {
-			ads: ads
+router.get('/getAdCampaignStore', session.requireLogin, (req, res) => {
+	campaignStore.selectAllAdCampaigns().then(campaigns => {
+		adIDs = []
+		console.log('campaigns', campaigns)
+		// get all of the ad ids
+		campaigns.forEach(function(campaign){
+			adIDs.push(campaign.ad_id)
+			// once we have processed all the campaigns, get all the ads
+			if(adIDs.length === campaigns.length) {
+				console.log('done fetching ad ids')
+				adStore.selectAdsWhereInByID(adIDs).then(ads => {
+					res.render('advertisement', {
+						ads: ads
+					})
+				})
+			}
 		})
 	})
 })

--- a/podcast/routes.js
+++ b/podcast/routes.js
@@ -27,6 +27,15 @@ router.get('/podcast', session.requireLogin, (req, res) => {
 	})
 })
 
+/*
+ * Basic Flow for playing podcasts (subject to change):
+ * 1) check if there is a linked advertisement
+ * 		a) if there is a linked ad and there are still funds in escrow, play the ad
+ * 		b) after playing the ad, credit the content creator
+ * 		c) after playing the ad, debit the advertiser
+ * 		d) if the escrow contract is now out, unlink the ad and remove db connections
+ * 2) play the podcast
+ */
 /**
  * creates readstream to the requested file and pipes the output to response
  * 

--- a/podcast/routes.js
+++ b/podcast/routes.js
@@ -12,7 +12,7 @@ const session = require('../authentication/session')
 const fs = require('fs')
 const utils = require('../utils/utils')
 const campaignStore = require('../advertising/adcampaign/campaignStore')
-
+const walletStore = require('../wallet/walletStore')
 router.use(fileupload())
 router.use(bodyParser.json())
 
@@ -32,8 +32,8 @@ router.get('/podcast', session.requireLogin, (req, res) => {
  * Basic Flow for playing podcasts (subject to change):
  * 1) check if there is a linked advertisement
  * 		a) if there is a linked ad and there are still funds in escrow, play the ad
- * 		b) after playing the ad, credit the content creator
- * 		c) after playing the ad, debit the advertiser
+ * 		b) after playing the ad, debit the advertiser
+ * 		c) after playing the ad, credit the content creator
  * 		d) if the escrow contract is now out, unlink the ad and remove db connections
  * 2) play the podcast
  */
@@ -63,22 +63,102 @@ router.get('/play', function(req, res) {
 				campaignStore.getAdCampaignForAd(ad[0].id).then(campaign => {
 					// TODO There should only be one campaign per ad. There is no logic to check for
 					// this yet, so we just use the first row returned
-					console.log('campaign', campaign[0])
+					if(!campaign[0] || campaign === [] ){
+						return
+					}
+					else{
+						console.log('campaign', campaign[0])
+						let pricePerView = campaign[0].pay_per_view
+						if(Number(campaign[0].curr_amount) - Number(pricePerView) < 0.000000){
+							//there's no need to update an advertiser's wallet if they still have some dust
+							//in their escrow record since their personal wallet should not have been deducted
+							//that dust
+							
+							//remove the ad campaign. there's no money left!
+							campaignStore.deleteCampaign(campaign[0].id)
+							//also unlink the ad from this podcast
+							adStore.removeLink(podcastID, ad[0].id)
+						}
+						else{
+							//TODO this will have to be revamped with a 'playlist' of sorts and will be easier
+							// to implement after finalizing audio playing, which will now be the next step
+							console.log('the escrow has sufficient funds')
+							//play the ad
+							let adPath = utils.getPathToFileStore() + ad[0].path
+							console.log('ad path', adPath)
+							fs.exists(adPath, function(exists){
+								if(exists){
+									let rstream = fs.createReadStream(adPath)
+									rstream.on('error', function(err){
+										console.log('error!!', err)
+									})
+									//TODO this doesn't work, but will be made functional upon implementing
+									// an audio player
+									rstream.on('finish', function(){
+										console.log("finished!!!!!!")
+										//TODO if any of these fail, they should all be rolled back
+										//once the ad has finished playing, debit the advertiser and escrow/campaign record
+										let updatedCampaignBalance = Number(campaign[0].curr_amount) - Number(pricePerView)
+										campaignStore.updateCurrAmount(campaign[0].id, updatedCampaignBalance)
+										let advertiserWalletBalance = walletStore.getUserBalance(ad[0].owner_id)
+										let updatedAdvertiserBalance = Number(advertiserWalletBalance) - Number(pricePerView)
+										walletStore.updateUserBalance(ad[0].owner_id, updatedAdvertiserBalance)
+						
+										//credit the content creator
+										let contentCreatorWalletBalance = walletStore.getUserBalance(req.query.owner_id)
+										let contentCreatorUpdatedBalance = Number(contentCreatorWalletBalance) + Number(payPerView)
+										walletStore.updateUserBalance(req.query.owner_id, contentCreatorUpdatedBalance)
+										
+										//check if there are still sufficient funds in escrow
+										campaignStore.getAdCampaignForAd(ad[0].id).then(campaign => {
+											// TODO There should only be one campaign per ad. There is no logic to check for
+											// this yet, so we just use the first row returned
+											if(!campaign[0] || campaign === [] ){
+												return
+											}
+											else{
+												console.log('campaign', campaign[0])
+												let pricePerView = campaign[0].pay_per_view
+												//if not, remove the campaign and unlink the ad
+												if(Number(campaign[0].curr_amount) - Number(pricePerView) < 0.000000){
+													//there's no need to update an advertiser's wallet if they still have some dust
+													//in their escrow record since their personal wallet should not have been deducted
+													//that dust
+							
+													//remove the ad campaign. there's no money left!
+													campaignStore.deleteCampaign(campaign[0].id)
+													//also unlink the ad from this podcast
+													adStore.removeLink(podcastID, ad[0].id)
+												}
+											}
+										})
+										
+										//play the podcast
+										let podcastPath = utils.getPathToFileStore() + req.query.path
+										console.log("file: " + podcastPath)
+										fs.exists(podcastPath, function(exists){
+											if(exists){
+												let podcastStream = fs.createReadStream(podcastPath)
+												podcastStream.pipe(res)
+											}
+											else {
+												res.sendStatus(400)
+											}
+										})
+									})
+									rstream.pipe(res)
+								}
+								else {
+									console.log('error playing advertisement')
+									res.sendStatus(400)
+								}
+							})
+						}
+					}
 				})
 			//TODO link ad audio with podcast audio. will probably need a special library
 			//TODO for now, both audio files are just played consecutively
 			})
-		}
-	})
-	let path = utils.getPathToFileStore() + req.query.path
-	console.log("file: " + path)
-	fs.exists(path, function(exists){
-		if(exists){
-			let rstream = fs.createReadStream(path)
-			rstream.pipe(res)
-		}
-		else {
-			res.sendStatus(400)
 		}
 	})
 })

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -15,7 +15,7 @@
 	<form action="/upload" method = "get">
           <button>Upload</button>
     </form>  
-    <form action="/getAddStore" method = "get">
+    <form action="/getAdCampaignStore" method = "get">
           <button>Link Advertisement</button>
     </form>
     <form action="/wallet" method = "get">


### PR DESCRIPTION
This pull request establishes the flow for playing an adlinked podcast:

1) check if there is a linked advertisement
  		a) if there is a linked ad and there are still funds in escrow, play the ad
 		b) after playing the ad, debit the advertiser
 		c) after playing the ad, credit the content creator
 		d) if the escrow contract is now out, unlink the ad and remove db connections
2) play the podcast

In order to finish this functionality, the audio player must be implemented such that it can handle autoplaying playlists. This will be the next step.